### PR TITLE
autofocus spelling fix

### DIFF
--- a/src/components/CodeInput.vue
+++ b/src/components/CodeInput.vue
@@ -12,7 +12,7 @@
         <input
           :type="type === 'number' ? 'tel' : type"
           :pattern="type === 'number' ? '[0-9]' : null"
-          :autoFocus="autoFocus && !loading && index === autoFocusIndex"
+          :autofocus="autoFocus && !loading && index === autoFocusIndex"
           :style="{
             width: `${fieldWidth}px`,
             height: `${fieldHeight}px`


### PR DESCRIPTION
:autoFocus should be :autofocus according to https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus